### PR TITLE
DHIS Deployment With Let's Encrypt, MySQL Backup Directory

### DIFF
--- a/roles/dhis2/defaults/main.yml
+++ b/roles/dhis2/defaults/main.yml
@@ -13,3 +13,6 @@ dhis_tomcat_fsize_threshold: "10485760"
 dhis_version: "2.26"
 dhis_libpq_dev_version: "9.6.2*"
 dhis_python_psycopg2_version: "2.6.1*"
+dhis_certs_from_letsencrypt: True
+ssl_key: "{{ dhis_site_name }}-key.pem"
+ssl_cert: "{{ dhis_site_name }}-fullchain.pem"

--- a/roles/mysql-backup/tasks/main.yml
+++ b/roles/mysql-backup/tasks/main.yml
@@ -41,6 +41,8 @@
     - { src: "templates/etc/mysqlbkup.config.j2", dest: "/etc/mysqlbkup.config" }
 
 - name: Make sure the backup directory exists
+  become: yes
+  become_user: "root"
   file:
     path: "{{ mysql_backup_dir }}"
     state: directory


### PR DESCRIPTION
Add support for deploying DHIS with Let's Encrypt certs. Run the task for creating the MySQL backup directory as root.