### PR TITLE
Add The SSH Role

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "roles/certbot"]
 	path = roles/certbot
 	url = git@github.com:onaio/ansible-certbot.git
+[submodule "roles/ssh"]
+	path = roles/ssh
+	url = git@github.com:onaio/ansible-ssh.git

--- a/setup-server.yml
+++ b/setup-server.yml
@@ -1,8 +1,14 @@
 - hosts: monitored-servers
   gather_facts: False
+  become: yes
   pre_tasks:
     - include_tasks: tasks/python2-ubuntu.yml
     - name: Setup Ansible
       setup:
   roles:
-    - server-monitoring
+    - role: ssh
+      tags:
+        - ssh
+    - role: server-monitoring
+      tags:
+        - monitoring


### PR DESCRIPTION
Add role for configuring SSH access. Add the role to the setup-server.yml
playbook.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>