### PR TITLE
Switch To A Fixed Handler Name For Tomcat Restart

### DIFF
--- a/roles/dhis2/handlers/main.yml
+++ b/roles/dhis2/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: restart {{ dhis_tomcat_instance }}
-  systemd:
-    name: "{{ dhis_tomcat_instance }}"
-    state: restarted
-  become: yes

--- a/roles/dhis2/tasks/main.yml
+++ b/roles/dhis2/tasks/main.yml
@@ -93,4 +93,4 @@
     url: http://s3-eu-west-1.amazonaws.com/releases.dhis2.org/{{ dhis_version }}/dhis.war
     dest: "{{ dhis_user_home }}/{{ dhis_tomcat_instance }}/webapps/dhis.war"
   notify:
-    - "restart {{ dhis_tomcat_instance }}"
+    - "restart tomcat instance"

--- a/roles/dhis2/tasks/main.yml
+++ b/roles/dhis2/tasks/main.yml
@@ -93,4 +93,4 @@
     url: http://s3-eu-west-1.amazonaws.com/releases.dhis2.org/{{ dhis_version }}/dhis.war
     dest: "{{ dhis_user_home }}/{{ dhis_tomcat_instance }}/webapps/dhis.war"
   notify:
-    - "restart tomcat instance"
+    - "restart tomcat7 instance"

--- a/roles/openmrs/handlers/main.yml
+++ b/roles/openmrs/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: restart {{ openmrs_tomcat_instance }}
-  systemd:
-    name: "{{ openmrs_tomcat_instance }}"
-    state: restarted
-  become: yes

--- a/roles/opensrp/handlers/main.yml
+++ b/roles/opensrp/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: restart {{ opensrp_tomcat_instance }}
-  systemd:
-    name: "{{ opensrp_tomcat_instance }}"
-    state: restarted
-  become: yes

--- a/roles/tomcat7/handlers/main.yml
+++ b/roles/tomcat7/handlers/main.yml
@@ -1,4 +1,4 @@
-- name: restart tomcat instance
+- name: restart tomcat7 instance
   systemd:
     name: "{{ tomcat_instance }}"
     state: restarted

--- a/roles/tomcat7/handlers/main.yml
+++ b/roles/tomcat7/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: restart tomcat instance
+  systemd:
+    name: "{{ tomcat_instance }}"
+    state: restarted
+  become: yes

--- a/roles/tomcat7/tasks/tomcat_user_instance.yml
+++ b/roles/tomcat7/tasks/tomcat_user_instance.yml
@@ -31,7 +31,7 @@
     group: "{{ tomcat_system_group }}"
     mode: 0744
   notify:
-    - "restart tomcat instance"
+    - "restart tomcat7 instance"
   tags:
    - tomcat-user-instance
 
@@ -48,7 +48,7 @@
     - "server.xml"
     - "web.xml"
   notify:
-      - "restart tomcat instance"
+      - "restart tomcat7 instance"
   tags:
      - tomcat-user-instance
 
@@ -72,7 +72,7 @@
     src: "etc/systemd/system/tomcat_user_instance.service.j2"
     dest: "/etc/systemd/system/{{ tomcat_instance }}.service"
   notify:
-    - "restart tomcat instance"
+    - "restart tomcat7 instance"
 
   tags:
    - openmrs-tomcat-user

--- a/roles/tomcat7/tasks/tomcat_user_instance.yml
+++ b/roles/tomcat7/tasks/tomcat_user_instance.yml
@@ -31,7 +31,7 @@
     group: "{{ tomcat_system_group }}"
     mode: 0744
   notify:
-    - "restart {{ tomcat_instance }}"
+    - "restart tomcat instance"
   tags:
    - tomcat-user-instance
 
@@ -48,7 +48,7 @@
     - "server.xml"
     - "web.xml"
   notify:
-      - "restart {{ tomcat_instance }}"
+      - "restart tomcat instance"
   tags:
      - tomcat-user-instance
 
@@ -72,7 +72,7 @@
     src: "etc/systemd/system/tomcat_user_instance.service.j2"
     dest: "/etc/systemd/system/{{ tomcat_instance }}.service"
   notify:
-    - "restart {{ tomcat_instance }}"
+    - "restart tomcat instance"
 
   tags:
    - openmrs-tomcat-user


### PR DESCRIPTION
Remove the tomcat_instance variable from the name of the handler for
restarting the tomcat instance. This is because the handler isn't being
detected when a variable is put in the name.