### PR TITLE
Update OpenMRS application from 2.1.3 to 2.1.4

### DIFF
--- a/roles/openmrs/defaults/main.yml
+++ b/roles/openmrs/defaults/main.yml
@@ -8,7 +8,7 @@ tomcat_https_port: 8443
 openmrs_tomcat_max_filesize: "52428800"
 openmrs_tomcat_fsize_threshold: "10485760"
 catalina_ops: "-Xms1500M -Xmx1500M"
-openmrs_version: "2.1.3"
+openmrs_version: "2.1.4"
 openmrs_nginx_max_filesize: "50M"
 openmrs_install_name: "openmrs"
 openmrs_mysql_user: "openmrs"

--- a/roles/openmrs/defaults/main.yml
+++ b/roles/openmrs/defaults/main.yml
@@ -28,3 +28,5 @@ openmrs_system_user: "openmrs"
 openmrs_tomcat_instance: "tomcat-openmrs"
 openmrs_tomcat_user_home: "/home/{{ openmrs_system_user }}"
 openmrs_home_directory: "{{ openmrs_tomcat_user_home }}/{{ openmrs_tomcat_instance }}/.OpenMRS"
+openmrs_mysql_connection_url: "jdbc:mysql://{{ openmrs_mysql_host }}:{{ openmrs_mysql_port }}/{{ openmrs_mysql_database }}?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull"
+

--- a/roles/openmrs/templates/usr/share/tomcat7/.OpenMRS/openmrs-runtime.properties.j2
+++ b/roles/openmrs/templates/usr/share/tomcat7/.OpenMRS/openmrs-runtime.properties.j2
@@ -1,6 +1,6 @@
 connection.username={{ openmrs_mysql_user }}
 connection.password={{ openmrs_mysql_password }}
-connection.url=jdbc:mysql://{{ openmrs_mysql_host }}:{{ openmrs_mysql_port }}/openmrs?autoReconnect=true&sessionVariables=storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+connection.url=jdbc:mysql://{{ openmrs_mysql_host }}:{{ openmrs_mysql_port }}/openmrs?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
 module.allow_web_admin=true
 auto_update_database=false
 sync.mandatory=false

--- a/roles/openmrs/templates/usr/share/tomcat7/.OpenMRS/openmrs-runtime.properties.j2
+++ b/roles/openmrs/templates/usr/share/tomcat7/.OpenMRS/openmrs-runtime.properties.j2
@@ -1,7 +1,6 @@
 connection.username={{ openmrs_mysql_user }}
 connection.password={{ openmrs_mysql_password }}
-connection.url=
-jdbc:mysql://{{ openmrs_mysql_connection_url }}
+connection.url={{ openmrs_mysql_connection_url }}
 module.allow_web_admin=true
 auto_update_database=false
 sync.mandatory=false

--- a/roles/openmrs/templates/usr/share/tomcat7/.OpenMRS/openmrs-runtime.properties.j2
+++ b/roles/openmrs/templates/usr/share/tomcat7/.OpenMRS/openmrs-runtime.properties.j2
@@ -1,6 +1,7 @@
 connection.username={{ openmrs_mysql_user }}
 connection.password={{ openmrs_mysql_password }}
-connection.url=jdbc:mysql://{{ openmrs_mysql_host }}:{{ openmrs_mysql_port }}/openmrs?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+connection.url=
+jdbc:mysql://{{ openmrs_mysql_connection_url }}
 module.allow_web_admin=true
 auto_update_database=false
 sync.mandatory=false

--- a/sample-invetories/zeir-sample/staging/host_vars/host1/vars.yml
+++ b/sample-invetories/zeir-sample/staging/host_vars/host1/vars.yml
@@ -15,7 +15,7 @@ tomcat_max_filesize: "52428800"
 tomcat_fsize_threshold: "10485760"
 catalina_ops: "-Xms1500M -Xmx1500M"
 certs_from_letsencrypt: true
-openmrs_version: "2.1.3"
+openmrs_version: "2.1.4"
 openmrs_nginx_max_filesize: "50M"
 openmrs_site_name: "openmrs-zeir-sample"
 openmrs_install_name: "openmrs"
@@ -85,7 +85,7 @@ openmrs_modules_v2:
   - "uicommons-2.6.0"
   - "uiframework-3.13.0"
   - "uilibrary-2.0.6"
-  - "webservices.rest-2.22.0"
+  - "webservices.rest-2.24.0"
 
 opensrp_mysql_port: "{{ mysql_port }}"
 opensrp_mysql_host: "localhost"


### PR DESCRIPTION
Due to [Vulnerabilities](https://www.bishopfox.com/news/2019/02/openmrs-insecure-object-deserialization/) in the current version of OpenMRS 

-Update OpenMRS application from 2.1.3 to 2.1.4
-update OpenMRS REST module from 2.22.0 to 2.24.0

