### PR TITLE
Set the JAVA_HOME Env Var In DHIS2 Env File

### DIFF
--- a/roles/dhis2/defaults/main.yml
+++ b/roles/dhis2/defaults/main.yml
@@ -3,6 +3,7 @@ dhis_version: "2.26"
 dhis_java_ops: "-Xmx2048m -Xms2048m"
 dhis_java_packages:
   - openjdk-8-jre
+dhis_java_home: "/usr/lib/jvm/java-8-openjdk-amd64"
 dhis_user_home: "/home/{{ dhis_system_user }}"
 dhis_system_user: dhis2
 dhis_system_group: dhis2

--- a/roles/dhis2/templates/dhis_user_home/dhis_tomcat_instance/bin/setenv.sh.j2
+++ b/roles/dhis2/templates/dhis_user_home/dhis_tomcat_instance/bin/setenv.sh.j2
@@ -2,6 +2,7 @@
 #
 
 export JAVA_OPTS='{{ dhis_java_ops }}'
+export JAVA_HOME='{{ dhis_java_home }}'
 export DHIS2_HOME='{{ dhis_user_home }}/config'
 
 CATALINA_HOME=/usr/share/tomcat7


### PR DESCRIPTION
Since we aren't using Oracle JDK for DHIS2 (which seems to be what
Tomcat 7 sets as the default JAVA_HOME) explicity set the environment
variable in DHIS2's setenv.sh file.

Signed-off-by: Jason Rogena <jason@rogena.me>