### PR TITLE
Configurable OpenMRS Hibernate Connection Pool Vars

### DIFF
--- a/roles/dhis2/meta/main.yml
+++ b/roles/dhis2/meta/main.yml
@@ -13,7 +13,7 @@ dependencies:
   tomcat_system_group: "{{ dhis_system_group }}"
   tomcat_user_home: "{{ dhis_user_home }}"
   tomcat_instance: "{{ dhis_tomcat_instance }}"
-  tomcat_Working_directory: "{{ tomcat_user_home }}/{{ tomcat_instance }}"
+  tomcat_working_directory: "{{ tomcat_user_home }}/{{ tomcat_instance }}"
   tomcat_http_port: "{{ dhis_tomcat_http_port }}"
   tomcat_shutdown_port: "{{ dhis_tomcat_shutdown_port }}"
   tomcat_max_filesize: "{{ dhis_tomcat_max_filesize }}"

--- a/roles/openmrs/defaults/main.yml
+++ b/roles/openmrs/defaults/main.yml
@@ -32,6 +32,10 @@ openmrs_mysql_connection_url: "jdbc:mysql://{{ openmrs_mysql_host }}:{{ openmrs_
 openmrs_install_mysql: yes
 openmrs_mysql_root_user: "root"
 
+# Hibernate
+openmrs_hibernate_c3p0_min_size: 5
+openmrs_hibernate_c3p0_timeout: 150
+openmrs_hibernate_c3p0_idle_test_period: 120
 
 # SSL
 openmrs_ssl_src_dir: "/etc/letsencrypt/live/{{ openmrs_site_name }}"

--- a/roles/openmrs/defaults/main.yml
+++ b/roles/openmrs/defaults/main.yml
@@ -30,8 +30,7 @@ openmrs_tomcat_user_home: "/home/{{ openmrs_system_user }}"
 openmrs_home_directory: "{{ openmrs_tomcat_user_home }}/{{ openmrs_tomcat_instance }}/.OpenMRS"
 openmrs_mysql_connection_url: "jdbc:mysql://{{ openmrs_mysql_host }}:{{ openmrs_mysql_port }}/{{ openmrs_mysql_database }}?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull"
 openmrs_install_mysql: yes
-opensrp_mysql_root_user: "root"
-
+openmrs_mysql_root_user: "root"
 
 
 # SSL

--- a/roles/openmrs/meta/main.yml
+++ b/roles/openmrs/meta/main.yml
@@ -6,7 +6,7 @@ dependencies:
   tomcat_system_group: "{{ tomcat_group }}"
   tomcat_user_home: "{{ openmrs_tomcat_user_home }}"
   tomcat_instance: "{{ openmrs_tomcat_instance }}"
-  tomcat_Working_directory: "{{ tomcat_user_home }}/{{ tomcat_instance }}/.OpenMRS"
+  tomcat_working_directory: "{{ tomcat_user_home }}/{{ tomcat_instance }}/.OpenMRS"
   tomcat_http_port: "{{ openmrs_tomcat_http_port }}"
   tomcat_shutdown_port: "{{ openmrs_tomcat_shutdown_port }}"
   tomcat_max_filesize: "{{ openmrs_tomcat_max_filesize }}"

--- a/roles/openmrs/tasks/main.yml
+++ b/roles/openmrs/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Create the OpenMRS MySQL Database
   mysql_db:
     login_host: "{{ openmrs_mysql_host }}"
-    login_user: "{{ opensrp_mysql_root_user }}"
+    login_user: "{{ openmrs_mysql_root_user }}"
     login_password: "{{ mysql_root_password }}"
     name: "{{ openmrs_mysql_database }}"
     state: present
@@ -10,7 +10,7 @@
 - name: Create the OpenMRS MySQL User
   mysql_user:
     login_host: "{{ openmrs_mysql_host }}"
-    login_user: "{{ opensrp_mysql_root_user }}"
+    login_user: "{{ openmrs_mysql_root_user }}"
     login_password: "{{ mysql_root_password }}"
     name: "{{ openmrs_mysql_user }}"
     password: "{{ openmrs_mysql_password }}"
@@ -33,7 +33,7 @@
   become_user: "root"
   mysql_db:
     name: "{{ openmrs_mysql_database }}"
-    login_user: "{{ opensrp_mysql_root_user }}"
+    login_user: "{{ openmrs_mysql_root_user }}"
     login_password: "{{ mysql_root_password }}"
     login_host: "{{ openmrs_mysql_host }}"
     state: import

--- a/roles/openmrs/templates/usr/share/tomcat7/.OpenMRS/openmrs-runtime.properties.j2
+++ b/roles/openmrs/templates/usr/share/tomcat7/.OpenMRS/openmrs-runtime.properties.j2
@@ -4,3 +4,8 @@ connection.url={{ openmrs_mysql_connection_url }}
 module.allow_web_admin=true
 auto_update_database=false
 sync.mandatory=false
+
+# Hibernate specific connection pool properties
+hibernate.c3p0.min_size={{ openmrs_hibernate_c3p0_min_size }}
+hibernate.c3p0.timeout={{ openmrs_hibernate_c3p0_timeout }}
+hibernate.c3p0.idle_test_period={{ openmrs_hibernate_c3p0_idle_test_period }}

--- a/roles/opensrp/meta/main.yml
+++ b/roles/opensrp/meta/main.yml
@@ -15,7 +15,7 @@ dependencies:
   tomcat_system_group: "{{ tomcat_group }}"
   tomcat_user_home: "{{ opensrp_user_home }}"
   tomcat_instance: "{{ opensrp_tomcat_instance }}"
-  tomcat_Working_directory: "{{ tomcat_user_home }}/{{ tomcat_instance }}"
+  tomcat_working_directory: "{{ tomcat_user_home }}/{{ tomcat_instance }}"
   tomcat_http_port: "{{ opensrp_tomcat_http_port }}"
   tomcat_shutdown_port: "{{ opensrp_tomcat_shutdown_port }}"
   tomcat_max_filesize: "{{ opensrp_tomcat_max_filesize }}"

--- a/roles/tomcat7/templates/etc/systemd/system/tomcat_user_instance.service.j2
+++ b/roles/tomcat7/templates/etc/systemd/system/tomcat_user_instance.service.j2
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-WorkingDirectory={{ tomcat_Working_directory }}
+WorkingDirectory={{ tomcat_working_directory }}
 User={{ tomcat_system_user }}
 Group={{ tomcat_system_group }}
 ExecStart={{ tomcat_user_home }}/{{ tomcat_instance }}/bin/startup.sh

--- a/roles/tomcat7/templates/etc/systemd/system/tomcat_user_instance.service.j2
+++ b/roles/tomcat7/templates/etc/systemd/system/tomcat_user_instance.service.j2
@@ -5,8 +5,8 @@ After=network.target
 [Service]
 Type=forking
 WorkingDirectory={{ tomcat_Working_directory }}
-User=root
-Group=root
+User={{ tomcat_system_user }}
+Group={{ tomcat_system_group }}
 ExecStart={{ tomcat_user_home }}/{{ tomcat_instance }}/bin/startup.sh
 ExecStop={{ tomcat_user_home }}/{{ tomcat_instance }}/bin/shutdown.sh
 


### PR DESCRIPTION
Makes the Hibernate variables described in #63 configurable with the default values set to what @githengi set in his deployment.

Fixes #63 