### PR TITLE
Add Swap Role For OpenMRS, OpenSRP & DHIS2

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -18,3 +18,6 @@
   name: onaio.certbot
   version: a19117aa21a497e9c33e06e52902910f4e26fb1e
   scm: git
+
+- src: geerlingguy.swap
+  version: 1.0.0

--- a/roles/dhis2/defaults/main.yml
+++ b/roles/dhis2/defaults/main.yml
@@ -31,6 +31,11 @@ dhis_certbot_mail_address: ""
 dhis_certbot_site_names:
   - "{{ dhis_site_name }}"
 
+# Swap
+dhis_swap_file_size_mb: 2048
+dhis_swap_swappiness: 10
+dhis_install_swap: false
+
 # NGINX
 dhis_nginx_proxy_read_timeout: "60s"
 dhis_nginx_max_filesize: "50M"

--- a/roles/dhis2/meta/main.yml
+++ b/roles/dhis2/meta/main.yml
@@ -1,5 +1,12 @@
 ---
 dependencies:
+- role: geerlingguy.swap
+  become: true
+  become_user: "root"
+  swap_file_size_mb: "{{ dhis_swap_file_size_mb }}"
+  swap_swappiness: "{{ dhis_swap_swappiness }}"
+  when: dhis_install_swap
+
 - role: geerlingguy.java
   java_packages: "{{ dhis_java_packages }}"
   become: true

--- a/roles/openmrs/defaults/main.yml
+++ b/roles/openmrs/defaults/main.yml
@@ -37,6 +37,11 @@ openmrs_hibernate_c3p0_min_size: 5
 openmrs_hibernate_c3p0_timeout: 150
 openmrs_hibernate_c3p0_idle_test_period: 120
 
+# Swap
+openmrs_swap_file_size_mb: 2048
+openmrs_swap_swappiness: 10
+openmrs_install_swap: false
+
 # SSL
 openmrs_ssl_src_dir: "/etc/letsencrypt/live/{{ openmrs_site_name }}"
 openmrs_ssl_cert_file: "fullchain.pem"

--- a/roles/openmrs/meta/main.yml
+++ b/roles/openmrs/meta/main.yml
@@ -1,5 +1,12 @@
 ---
 dependencies:
+- role: geerlingguy.swap
+  become: true
+  become_user: "root"
+  swap_file_size_mb: "{{ openmrs_swap_file_size_mb }}"
+  swap_swappiness: "{{ openmrs_swap_swappiness }}"
+  when: openmrs_install_swap
+
 - role: tomcat7
   install_tomcat_service: false
   tomcat_system_user: "{{ openmrs_system_user }}"

--- a/roles/opensrp/defaults/main.yml
+++ b/roles/opensrp/defaults/main.yml
@@ -86,6 +86,11 @@ opensrp_https_site: "{{ opensrp_site_name }}-https"
 opensrp_certbot_site_names: ["{{ opensrp_site_name }}"]
 opensrp_certbot_mail_address: ""
 
+# Swap
+opensrp_swap_file_size_mb: 2048
+opensrp_swap_swappiness: 10
+opensrp_install_swap: false
+
 # NGINX
 opensrp_nginx_sites:
   - server:

--- a/roles/opensrp/meta/main.yml
+++ b/roles/opensrp/meta/main.yml
@@ -1,5 +1,12 @@
 ---
 dependencies:
+- role: geerlingguy.swap
+  become: true
+  become_user: "root"
+  swap_file_size_mb: "{{ opensrp_swap_file_size_mb }}"
+  swap_swappiness: "{{ opensrp_swap_swappiness }}"
+  when: opensrp_install_swap
+
 - role: onaio.redis
   become: true
   become_user: "root"


### PR DESCRIPTION
Add a swap role as a dependency for installing swap for OpenMRS, OpenSRP,
and DHIS2. The reason why we've added it as a dependency for the apps, is
that it seems to be more of a Java dependency than a requirement for all
servers.

Fixes #4

Signed-off-by: Jason Rogena <jason@rogena.me>