### PR TITLE
Become root when copying over Logrotate file

### DIFF
--- a/roles/tomcat7/tasks/logrotate.yml
+++ b/roles/tomcat7/tasks/logrotate.yml
@@ -1,5 +1,7 @@
 ---
 - name: Copy the logrotate configuration
+  become: yes
+  become_user: "root"
   template:
     src: "etc/logrotate.d/tomcat_instance.j2"
     dest: "{{ tomcat_logrotate_conf_dest }}"


### PR DESCRIPTION
The template task for copying over the Tomcat logrotate configuration
requires to be ran as a privileged user. Add the become and become_user
directives to the task with user set as "root".

Co-authored-by: Emmanuel Tarus <manutarus@gmail.com>
Signed-off-by: Jason Rogena <jason@rogena.me>