### PR TITLE
Run apt update in Server Setup Packer File

### DIFF
--- a/packer/ami-server-setup.json
+++ b/packer/ami-server-setup.json
@@ -50,6 +50,13 @@
     ],
     "provisioners": [
         {
+            "type": "shell",
+            "inline": [
+                "sleep 30",
+                "sudo apt-get update"
+            ]
+        },
+        {
             "type": "ansible",
             "extra_arguments": [
                 "--vault-password-file={{ user `ansible_vault_file` }}",


### PR DESCRIPTION
To avoid the Packer instance from exiting with apt errors, run apt-get
update in the host before running Ansible.

Signed-off-by: Jason Rogena <jason@rogena.me>