### PR TITLE
Adds Support for Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "submodules"
+    directory: "/"
+    update_schedule: "daily"
+    default_reviewers:
+      - "jasonrogena"
+      - "manutarus"


### PR DESCRIPTION
Since this repository has Git sub-modules that are constantly being
updated, add support for Dependabot to create PRs whenever one is
updated.

Signed-off-by: Jason Rogena <jason@rogena.me>