### PR TITLE
Updates How Tomcat Log Rotation is Done

### DIFF
--- a/roles/tomcat7/defaults/main.yml
+++ b/roles/tomcat7/defaults/main.yml
@@ -9,3 +9,6 @@ tomcat_user: "tomcat7"
 tomcat_group: "tomcat7"
 # The number of days to keep Tomcat logs before deleting them
 tomcat_logs_max_age_days: 90
+# logs that will be rotated using logrotate
+tomcat_rotated_logs:
+  - "{{ tomcat_logs_dir }}/catalina.out"

--- a/roles/tomcat7/templates/etc/logrotate.d/tomcat_instance.j2
+++ b/roles/tomcat7/templates/etc/logrotate.d/tomcat_instance.j2
@@ -1,4 +1,4 @@
-{{ tomcat_logs_dir }}/* {
+{% for tomcat_rotated_log in tomcat_rotated_logs %}{{ tomcat_rotated_log }} {% endfor %}}{
   copytruncate
   daily
   rotate {{ tomcat_logs_max_age_days }}


### PR DESCRIPTION
By default, only rotate the catalina.out log inside the tomcat_logs_dir
directory. This is because it's likely that the other logs in that
directory are logrotated using some other mechanism. For example, both
OpenSRP and OpenMRS rotate the localhost.log file differently.

Signed-off-by: Jason Rogena <jason@rogena.me>