### PR TITLE
Creating the PostgreSQL User & DB from DHIS Role

### DIFF
--- a/roles/dhis2/defaults/main.yml
+++ b/roles/dhis2/defaults/main.yml
@@ -23,7 +23,11 @@ dhis_tomcat_fsize_threshold: "10485760"
 dhis_postgresql_user: dhis
 dhis_postgresql_database: dhis2
 dhis_postgresql_password: ""
-dhis_postgresql_connection_url: "jdbc:postgresql:{{ dhis_postgresql_database }}"
+dhis_postgresql_host: localhost
+dhis_postgresql_port: 5432
+dhis_postgresql_connection_url: "jdbc:postgresql://{{ dhis_postgresql_host }}:{{ dhis_postgresql_port }}/{{ dhis_postgresql_database }}"
+dhis_postgresql_login_user: root
+dhis_postgres_login_password:
 
 # Certbot
 dhis_certbot_create_certs: true

--- a/roles/dhis2/tasks/main.yml
+++ b/roles/dhis2/tasks/main.yml
@@ -37,6 +37,37 @@
     group: "{{ dhis_system_group }}"
     mode: 0600
 
+- name: Install PostgreSQL prerequisites
+  become: yes
+  become_user: "root"
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libpq-dev
+    - python-psycopg2
+
+- name: Make sure the DHIS database exists
+  postgresql_db:
+    name: "{{ dhis_postgresql_database }}"
+    login_host: "{{ dhis_postgresql_host }}"
+    port: "{{ dhis_postgresql_port }}"
+    login_user: "{{ dhis_postgresql_login_user }}"
+    login_password: "{{ dhis_postgres_login_password }}"
+    encoding: UTF-8
+
+- name: Ensure DHIS psql user has the right access level to the database
+  postgresql_user:
+    db: "{{ dhis_postgresql_database }}"
+    login_host: "{{ dhis_postgresql_host }}"
+    port: "{{ dhis_postgresql_port }}"
+    login_user: "{{ dhis_postgresql_login_user }}"
+    login_password: "{{ dhis_postgres_login_password }}"
+    name: "{{ dhis_postgresql_user }}"
+    password: "{{ dhis_postgresql_password }}"
+    encrypted: yes
+    priv: ALL
+
 - name: Download The DHIS2 War
   become: yes
   become_user: "root"

--- a/roles/dhis2/tasks/main.yml
+++ b/roles/dhis2/tasks/main.yml
@@ -25,7 +25,7 @@
     owner: "{{ dhis_system_user }}"
     group: "{{ dhis_system_group }}"
     state: directory
-    mode: 0644
+    mode: 0750
 
 - name: Copy DHIS Config
   become: yes


### PR DESCRIPTION
Adds the ability to create the PostgreSQL user and database from the
DHIS2 role. Needed for deployments that use managed instances of
Postgres.