### PR TITLE
Support Setting Timeouts for Load Balanced VMs

### DIFF
--- a/terraform/modules/providers/aws/load-balanced-virtual-machines/network.tf
+++ b/terraform/modules/providers/aws/load-balanced-virtual-machines/network.tf
@@ -16,6 +16,7 @@ module "lb" {
   lb_domain_name                     = var.lbvm_domain_name
   lb_domain_name_cnames              = var.lbvm_domain_name_cnames
   lb_ssl_policy                      = var.lbvm_lb_ssl_policy
+  lb_idle_timeout                    = var.lbvm_lb_idle_timeout
   lb_logs_object_storage_bucket_name = var.lbvm_lb_logs_object_storage_bucket_name
 }
 

--- a/terraform/modules/providers/aws/load-balanced-virtual-machines/variables.tf
+++ b/terraform/modules/providers/aws/load-balanced-virtual-machines/variables.tf
@@ -39,6 +39,10 @@ variable "lbvm_lb_instance_port" {
   default = 80
 }
 
+variable "lbvm_lb_idle_timeout" {
+  default = 300
+}
+
 variable "lbvm_lb_instance_protocol" {
   default = "HTTP"
 }


### PR DESCRIPTION
Support overriding the default load balancer timeout when setting up
load balanced virtual machines using Terraform.

Signed-off-by: Jason Rogena <jason@rogena.me>