### PR TITLE
Restart Tomcat Instance When Service Exits

### DIFF
--- a/roles/tomcat7/templates/etc/systemd/system/tomcat_user_instance.service.j2
+++ b/roles/tomcat7/templates/etc/systemd/system/tomcat_user_instance.service.j2
@@ -9,6 +9,8 @@ User={{ tomcat_system_user }}
 Group={{ tomcat_system_group }}
 ExecStart={{ tomcat_user_home }}/{{ tomcat_instance }}/bin/startup.sh
 ExecStop={{ tomcat_user_home }}/{{ tomcat_instance }}/bin/shutdown.sh
+Restart=always
+RestartSec=15
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Configures the service to always be restarted when the service
process exits, is killed, or a timeout is reached

Signed-off-by: Morris Mukiri <morrismukiri@gmail.com>