### PR TITLE
Adds Support for Stickiness on the Load Balancer

### DIFF
--- a/terraform/modules/providers/aws/load-balanced-virtual-machines/network.tf
+++ b/terraform/modules/providers/aws/load-balanced-virtual-machines/network.tf
@@ -18,5 +18,7 @@ module "lb" {
   lb_ssl_policy                      = var.lbvm_lb_ssl_policy
   lb_idle_timeout                    = var.lbvm_lb_idle_timeout
   lb_logs_object_storage_bucket_name = var.lbvm_lb_logs_object_storage_bucket_name
+  lb_stickiness_cookie_duration      = var.lbvm_lb_stickiness_cookie_duration
+  lb_stickiness_enabled              = var.lbvm_lb_stickiness_enabled
 }
 

--- a/terraform/modules/providers/aws/load-balanced-virtual-machines/variables.tf
+++ b/terraform/modules/providers/aws/load-balanced-virtual-machines/variables.tf
@@ -70,3 +70,12 @@ variable "lbvm_domain_name_cnames" {
 variable "lbvm_lb_logs_object_storage_bucket_name" {
 }
 
+variable "lbvm_lb_stickiness_cookie_duration" {
+  type    = number
+  default = 86400
+}
+
+variable "lbvm_lb_stickiness_enabled" {
+  type    = bool
+  default = false
+}

--- a/terraform/modules/providers/aws/load-balancer/network.tf
+++ b/terraform/modules/providers/aws/load-balancer/network.tf
@@ -70,6 +70,12 @@ resource "aws_alb_target_group" "https" {
     matcher             = var.lb_health_check_healthy_status_code
   }
 
+  stickiness {
+    type            = var.lb_stickiness_type
+    cookie_duration = var.lb_stickiness_cookie_duration
+    enabled         = var.lb_stickiness_enabled
+  }
+
   tags = {
     OwnerList       = var.lb_owner
     EnvironmentList = var.lb_env

--- a/terraform/modules/providers/aws/load-balancer/variables.tf
+++ b/terraform/modules/providers/aws/load-balancer/variables.tf
@@ -94,6 +94,21 @@ variable "lb_logs_user_identifiers" {
   ] // cn-northwest-1**
 }
 
+variable "lb_stickiness_type" {
+  type    = string
+  default = "lb_cookie"
+}
+
+variable "lb_stickiness_cookie_duration" {
+  type    = number
+  default = 86400
+}
+
+variable "lb_stickiness_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "lb_logs_object_storage_bucket_name" {
 }
 


### PR DESCRIPTION
To support how OpenSRP Server handles sessions, add support for
stickiness on the load balancer.

Co-authored-by: Samuel Githengi <samuel.githengi@gmail.com>
Signed-off-by: Jason Rogena <jason@rogena.me>