### PR TITLE
Set Maximum Tomcat Log File Size and Archives to Keep

### DIFF
--- a/roles/tomcat7/defaults/main.yml
+++ b/roles/tomcat7/defaults/main.yml
@@ -9,6 +9,10 @@ tomcat_user: "tomcat7"
 tomcat_group: "tomcat7"
 # The number of days to keep Tomcat logs before deleting them
 tomcat_logs_max_age_days: 90
+# The maximum file size of Tomcat logs before rotating them
+tomcat_logs_max_file_size: 500M
+# The number of Tomcat log files to maintain
+tomcat_logs_archives_to_keep: 7
 # logs that will be rotated using logrotate
 tomcat_rotated_logs:
   - "{{ tomcat_logs_dir }}/catalina.out"

--- a/roles/tomcat7/templates/etc/logrotate.d/tomcat_instance.j2
+++ b/roles/tomcat7/templates/etc/logrotate.d/tomcat_instance.j2
@@ -1,9 +1,10 @@
 {% for tomcat_rotated_log in tomcat_rotated_logs %}{{ tomcat_rotated_log }} {% endfor %}{
   copytruncate
   daily
-  rotate {{ tomcat_logs_max_age_days }}
+  rotate {{ tomcat_logs_archives_to_keep }}
+  maxage {{ tomcat_logs_max_age_days }}
   compress
   missingok
-  delaycompress
+  size {{ tomcat_logs_max_file_size }}
   notifempty
 }


### PR DESCRIPTION
Set the number of Tomcat rotated log files, the maximum file size allowed before rotating them and immediately compress the log files.

Fixes #60

