### PR TITLE
Set delete_on_termination = false for root_block_device

### DIFF
--- a/terraform/modules/providers/aws/virtual-machine/compute.tf
+++ b/terraform/modules/providers/aws/virtual-machine/compute.tf
@@ -16,6 +16,7 @@ resource "aws_instance" "main" {
   associate_public_ip_address = var.vm_associate_public_ip_address
 
   root_block_device {
+    delete_on_termination = false
     volume_size = var.vm_instances[count.index]["volume_size"]
     volume_type = var.vm_instances[count.index]["volume_type"]
   }

--- a/terraform/modules/providers/aws/virtual-machine/compute.tf
+++ b/terraform/modules/providers/aws/virtual-machine/compute.tf
@@ -17,8 +17,8 @@ resource "aws_instance" "main" {
 
   root_block_device {
     delete_on_termination = false
-    volume_size = var.vm_instances[count.index]["volume_size"]
-    volume_type = var.vm_instances[count.index]["volume_type"]
+    volume_size           = var.vm_instances[count.index]["volume_size"]
+    volume_type           = var.vm_instances[count.index]["volume_type"]
   }
 
   tags = {


### PR DESCRIPTION
This is so that terraform does not attempt to recreate the root block device.