### PR TITLE
Adds CloudWatch Alarms for Load Balancer Health Checks

### DIFF
--- a/terraform/modules/providers/aws/load-balanced-virtual-machines/network.tf
+++ b/terraform/modules/providers/aws/load-balanced-virtual-machines/network.tf
@@ -20,5 +20,8 @@ module "lb" {
   lb_logs_object_storage_bucket_name = var.lbvm_lb_logs_object_storage_bucket_name
   lb_stickiness_cookie_duration      = var.lbvm_lb_stickiness_cookie_duration
   lb_stickiness_enabled              = var.lbvm_lb_stickiness_enabled
+  lb_alarm_alarm_actions             = var.lbvm_alarm_alarm_actions
+  lb_alarm_insufficient_data_actions = var.lbvm_alarm_insufficient_data_actions
+  lb_alarm_ok_actions                = var.lbvm_alarm_ok_actions
 }
 

--- a/terraform/modules/providers/aws/load-balanced-virtual-machines/variables.tf
+++ b/terraform/modules/providers/aws/load-balanced-virtual-machines/variables.tf
@@ -79,3 +79,21 @@ variable "lbvm_lb_stickiness_enabled" {
   type    = bool
   default = false
 }
+
+variable "lbvm_alarm_alarm_actions" {
+  type        = list(string)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+}
+
+variable "lbvm_alarm_insufficient_data_actions" {
+  type        = list(string)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+}
+
+variable "lbvm_alarm_ok_actions" {
+  type        = list(string)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+}

--- a/terraform/modules/providers/aws/load-balancer/variables.tf
+++ b/terraform/modules/providers/aws/load-balancer/variables.tf
@@ -128,3 +128,56 @@ variable "lb_domain_name" {
 variable "lb_domain_name_cnames" {
 }
 
+variable "lb_alarm_unhealthy_hosts_evaluation_periods" {
+  type        = string
+  default     = "1"
+  description = "The number of periods over which data is compared to the specified threshold."
+}
+
+variable "lb_alarm_unhealthy_hosts_period" {
+  type        = string
+  default     = "300"
+  description = "The period in seconds over which the average is applied."
+}
+
+variable "lb_alarm_unhealthy_hosts_threshold" {
+  type        = number
+  default     = 0.25
+  description = "The fraction of hosts that if become unhealthy an alarm is raised"
+}
+
+variable "lb_alarm_requests_5xx_count_evaluation_periods" {
+  type        = string
+  default     = "1"
+  description = "The number of periods over which data is compared to the specified threshold."
+}
+
+variable "lb_alarm_requests_5xx_count_period" {
+  type        = string
+  default     = "300"
+  description = "The period in seconds over which the sum is applied."
+}
+
+variable "lb_alarm_requests_5xx_threshold" {
+  type        = number
+  default     = 50
+  description = "The threshold of number of 5xx requests that if crossed, an alarm will be raised."
+}
+
+variable "lb_alarm_alarm_actions" {
+  type        = list(string)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+}
+
+variable "lb_alarm_insufficient_data_actions" {
+  type        = list(string)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+}
+
+variable "lb_alarm_ok_actions" {
+  type        = list(string)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+}


### PR DESCRIPTION
Add a CloudWatch alarms for when:

 - The number of unhealthy hosts on a load balancer cross a threshold
 - The number of 5XX requests served on a load balancer cross a
   threshold

Fixes #94

Signed-off-by: Jason Rogena <jason@rogena.me>