### PR TITLE
Add an EC2 Name Tag to Running AMI Builder

### DIFF
--- a/packer/ami-server-setup.json
+++ b/packer/ami-server-setup.json
@@ -35,12 +35,14 @@
                 "ProjectList": "{{ user `project` }}"
             },
             "run_tags": {
+                "Name": "{{ user `project` }}-{{ user `env` }}-{{ user `distribution_version` }}-{{ timestamp }}",
                 "OwnerList": "{{ user `owner` }}",
                 "EnvironmentList": "{{ user `env` }}",
                 "EndDate": "{{ user `end_date` }}",
                 "ProjectList": "{{ user `project` }}"
             },
             "run_volume_tags": {
+                "Name": "{{ user `project` }}-{{ user `env` }}-{{ user `distribution_version` }}-{{ timestamp }}",
                 "OwnerList": "{{ user `owner` }}",
                 "EnvironmentList": "{{ user `env` }}",
                 "EndDate": "{{ user `end_date` }}",


### PR DESCRIPTION
Add an EC2 name tag to an instance launched when building an AMI