### PR TITLE
Convert onaio.react from ansible galaxy requirement to a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "roles/postgresql"]
 	path = roles/postgresql
 	url = https://github.com/onaio/ansible-postgresql.git
+[submodule "roles/onaio.react"]
+	path = roles/onaio.react
+	url = https://github.com/onaio/ansible-react.git

--- a/requirements/ansible-galaxy.yml
+++ b/requirements/ansible-galaxy.yml
@@ -29,11 +29,6 @@
   version: 287f0b7ec647bada6df00980df8ff05caed74844
   scm: git
 
-- src: git+https://github.com/onaio/ansible-react
-  name: onaio.react
-  version: v0.0.2
-  scm: git
-
 - src: https://github.com/onaio/ansible-gpg-import.git
   name: onaio.gpg-import
   version: c5bb983d5b4bc5fec82a03d71543fefbe2ddd06e


### PR DESCRIPTION
Closes #181 
Converts [onaio.react](https://github.com/onaio/ansible-react) dependency from ansible galaxy requirement to a git submodule