### PR TITLE
Prefix tomcat to catalina_ops for tomcat 9

### DIFF
--- a/roles/tomcat9/defaults/main.yml
+++ b/roles/tomcat9/defaults/main.yml
@@ -8,6 +8,7 @@ tomcat_user: "tomcat"
 tomcat_group: "tomcat"
 tomcat_user_home: /opt
 tomcat_instance: tomcat
+tomcat_catalina_ops: ""
 # The number of days to keep Tomcat logs before deleting them
 tomcat_logs_max_age_days: 90
 # The maximum file size of Tomcat logs before rotating them

--- a/roles/tomcat9/meta/main.yml
+++ b/roles/tomcat9/meta/main.yml
@@ -22,7 +22,7 @@ dependencies: # noqa 701
       xms: "{{ tomcat_xms }}"
       java_opts:
         - name: CATALINA_OPTS
-          value: "{{ catalina_ops }}"
+          value: "{{ tomcat_catalina_ops }}"
         - name: JAVA_HOME
           value: "/usr/lib/jvm/java-11-openjdk-amd64"
    tags:


### PR DESCRIPTION
- [x] Prefix tomcat on `catalina_ops` for tomcat 9 to be able to differentiate from Catalina opts used on tomcat7 role

- [x] Default `tomcat_catalina_ops`