### PR TITLE
Adds the Ability to Set the Alicloud Subnet Newbits

### DIFF
--- a/terraform/modules/providers/alicloud/virtual-private-cloud/network.tf
+++ b/terraform/modules/providers/alicloud/virtual-private-cloud/network.tf
@@ -36,7 +36,7 @@ resource "alicloud_route_table" "main" {
 resource "alicloud_vswitch" "vpc_vswitches" {
   name              = "${var.vpc_name}-${count.index}"
   vpc_id            = alicloud_vpc.main.id
-  cidr_block        = cidrsubnet(alicloud_vpc.main.cidr_block, 8, count.index)
+  cidr_block        = cidrsubnet(alicloud_vpc.main.cidr_block, var.vpc_subnet_newbits, count.index)
   availability_zone = element(var.vpc_availability_zones, count.index)
   count             = length(var.vpc_availability_zones)
 

--- a/terraform/modules/providers/alicloud/virtual-private-cloud/variables.tf
+++ b/terraform/modules/providers/alicloud/virtual-private-cloud/variables.tf
@@ -36,3 +36,9 @@ variable "vpc_nat_gateway_specification" {
   type    = string
   default = "Small"
 }
+
+variable "vpc_subnet_newbits" {
+  type        = number
+  default     = 8
+  description = "The number of additional bits with which to extend the subnet prefix. For example, if given a prefix ending in /16 and a newbits value of 4, the resulting subnet address will have length /20"
+}


### PR DESCRIPTION
Add the ability to set the CIDR newbits[1] for subnets to be spawned by
the AliCloud VPC module.

1 - https://www.terraform.io/docs/configuration/functions/cidrsubnet.html

Signed-off-by: Jason Rogena <jason@rogena.me>