### PR TITLE
Updates Ansible SSH Timeout & Retries

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -12,6 +12,8 @@ strategy = mitogen_linear
 pipelining = True
 control_path = /tmp/ansible-ssh-%%h-%%p-%%r
 ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+timeout = 120
+retries = 5
 
 [inventory]
 enable_plugins = host_list, script, auto, yaml, ini, toml, aws_ec2


### PR DESCRIPTION
To prevent Ansible from timing out when deploying to hosts that take
long to connect to, set the SSH connection timeout to 120s and number of
retries to 5.

Signed-off-by: Jason Rogena <jason@rogena.me>