### PR TITLE
Allows Setting Alicloud ECS cloud-init User Data

### DIFF
--- a/terraform/modules/providers/alicloud/virtual-machine/compute.tf
+++ b/terraform/modules/providers/alicloud/virtual-machine/compute.tf
@@ -5,6 +5,7 @@ resource "alicloud_instance" "main" {
   system_disk_category          = var.vm_instances[count.index]["volume_type"]
   image_id                      = var.vm_instances[count.index]["parent_image"]
   system_disk_size              = var.vm_instances[count.index]["volume_size"]
+  user_data                     = contains(keys(var.vm_instances[count.index]), "user_data") ? var.vm_instances[count.index]["user_data"] : var.vm_user_data
   instance_name                 = "${var.vm_name}-${count.index}"
   internet_max_bandwidth_out    = var.vm_internet_max_bandwidth_out
   instance_charge_type          = "PostPaid"

--- a/terraform/modules/providers/alicloud/virtual-machine/variables.tf
+++ b/terraform/modules/providers/alicloud/virtual-machine/variables.tf
@@ -80,3 +80,18 @@ variable "vm_public_domain_names_host_record" {
   default     = "@"
   description = "Host record for the DNS A record for the load balancer."
 }
+
+variable "vm_user_data" {
+  type        = string
+  description = "The cloud-init user data to be applied to all the virtual machines. 'user_data' key in a VMs object inside the vm_instances variable will take presidence over this value."
+  default     = <<EOF
+#!/bin/bash
+
+set -e
+useradd -c ubuntu -s /bin/bash -m -d /home/ubuntu -U ubuntu -G sudo
+echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/100-cloud-init-ubuntu
+mkdir -p /home/ubuntu/.ssh
+cp /root/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys
+chown -R ubuntu:ubuntu /home/ubuntu/.ssh
+EOF
+}


### PR DESCRIPTION
Allows setting the Alicloud ECS cloud-init user data. By default, create
the ubuntu user in created ECS instances.

Signed-off-by: Jason Rogena <jason@rogena.me>