### PR TITLE
Prevent OpenSRP CA Bundle Default Value From Being Split Using Commas

### DIFF
--- a/roles/opensrp/defaults/main.yml
+++ b/roles/opensrp/defaults/main.yml
@@ -257,7 +257,7 @@ opensrp_whitelabeling_copy_files: []
 # MySQL CA Bundle url
 opensrp_mysql_ca_bundle_url: "https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem"
 # Postgres CA Bundle url
-opensrp_postgres_ca_bundle_content: "{{ lookup('url', 'https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem') }}"
+opensrp_postgres_ca_bundle_content: "{{ lookup('url', 'https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem', split_lines=false) }}"
 
 opensrp_compile_java_home: "/usr/lib/jvm/java-11-openjdk-amd64"
 


### PR DESCRIPTION
In the default value for opensrp_postgres_ca_bundle_content avoid returned content's lines from
being split using commas by adding the split_lines=false argument to the lookup function.