### PR TITLE
Allows Specifying AWS User Data for cloud-init

### DIFF
--- a/terraform/modules/providers/aws/virtual-machine-with-domain-names/compute.tf
+++ b/terraform/modules/providers/aws/virtual-machine-with-domain-names/compute.tf
@@ -10,6 +10,7 @@ module "vm" {
   vm_availability_zones          = var.vmdns_vm_availability_zones
   vm_firewall_rules              = var.vmdns_firewall_rules
   vm_instances                   = var.vmdns_vm_instances
+  vm_user_data                   = var.vmdns_vm_user_data
   vm_root_block_device_encrypted = var.vmdns_root_block_device_encrypted
 }
 

--- a/terraform/modules/providers/aws/virtual-machine-with-domain-names/variables.tf
+++ b/terraform/modules/providers/aws/virtual-machine-with-domain-names/variables.tf
@@ -30,6 +30,16 @@ variable "vmdns_vm_instances" {
   type = list(object({ group = string, parent_image = string, instance_type = string, volume_size = string, volume_type = string }))
 }
 
+variable "vmdns_vm_user_data" {
+  type        = string
+  description = "The cloud-init user data to be applied to all the virtual machines. 'user_data' key in a VMs object inside the vm_instances variable will take presidence over this value."
+  default     = <<EOF
+#!/bin/bash
+
+echo "Instance is up!"
+EOF
+}
+
 variable "vmdns_domain_zone_name" {
 }
 

--- a/terraform/modules/providers/aws/virtual-machine/compute.tf
+++ b/terraform/modules/providers/aws/virtual-machine/compute.tf
@@ -14,6 +14,7 @@ resource "aws_instance" "main" {
     count.index % length(data.aws_subnet.vpc_subnets),
   )
   associate_public_ip_address = var.vm_associate_public_ip_address
+  user_data                   = contains(keys(var.vm_instances[count.index]), "user_data") ? var.vm_instances[count.index]["user_data"] : var.vm_user_data
 
   root_block_device {
     encrypted   = var.vm_root_block_device_encrypted

--- a/terraform/modules/providers/aws/virtual-machine/variables.tf
+++ b/terraform/modules/providers/aws/virtual-machine/variables.tf
@@ -45,3 +45,13 @@ variable "vm_root_block_device_encrypted" {
   type    = bool
   default = false
 }
+
+variable "vm_user_data" {
+  type        = string
+  description = "The cloud-init user data to be applied to all the virtual machines. 'user_data' key in a VMs object inside the vm_instances variable will take presidence over this value."
+  default     = <<EOF
+#!/bin/bash
+
+echo "Instance is up!"
+EOF
+}


### PR DESCRIPTION
Add support for specifying the user data for cloud-init in AWS.

Signed-off-by: Jason Rogena <jason@rogena.me>