### PR TITLE
Changes the Code Directory for MyBatis to /opt/opensrp

### DIFF
--- a/roles/opensrp/tasks/postgresql.yml
+++ b/roles/opensrp/tasks/postgresql.yml
@@ -47,6 +47,7 @@
     - postgresql
 
 - name: Ensure checkout directory is empty
+  become: yes
   file:
     state: absent
     path: "{{ opensrp_remote_checkout_path }}"
@@ -54,6 +55,7 @@
     - postgresql
 
 - name: Checking out codebase
+  become: yes
   git:
     repo: "{{ opensrp_git_url }}"
     dest: "{{ opensrp_remote_checkout_path }}"
@@ -62,12 +64,20 @@
   tags:
     - postgresql
 
+
 - name: Copy the OpenSRP migrations environment configs
+  become: yes
   template:
     src: "templates/opensrp_remote_checkout_path/configs/assets/migrations/environments/opensrp_mybatis_env.properties.j2"
     dest: "{{ opensrp_remote_checkout_path }}/configs/assets/migrations/environments/{{ opensrp_mybatis_env }}.properties"
   tags:
     - postgresql
+
+- name: Make codebase readable
+  become: yes
+  file:
+    path: "{{ opensrp_remote_checkout_path }}"
+    mode: "0755"
 
 - name: Make sure the OpenSRP PostgreSQL database exists
   postgresql_db:
@@ -122,6 +132,7 @@
     - postgresql
 
 - name: Ensure checkout directory is empty
+  become: yes
   file:
     state: absent
     path: "{{ opensrp_remote_checkout_path }}"

--- a/roles/opensrp/vars/main.yml
+++ b/roles/opensrp/vars/main.yml
@@ -11,4 +11,4 @@ opensrp_oauth_dictionary:
     token_validity: access-token-validity
     callback_url: redirect-uri
     roles: authorities
-opensrp_remote_checkout_path: "/tmp/opensrp"
+opensrp_remote_checkout_path: "/opt/opensrp"


### PR DESCRIPTION
Install the OpenSRP code in /opt/opensrp instead of /tmp/opensrp in the
application server so that the code can be used to run the Mybatis
migrations.

Do this to cater for prebuilt images since servers that spin up based on
these images will have the /tmp directory empty on-boot.

Signed-off-by: Jason Rogena <jason@rogena.me>