### PR TITLE
replace psycopg2 libs

### DIFF
--- a/roles/opensrp/tasks/postgresql.yml
+++ b/roles/opensrp/tasks/postgresql.yml
@@ -41,7 +41,7 @@
     - python-migrate
     - postgresql
     - libpq-dev
-    - python-psycopg2
+    - python3-psycopg2
     - git
   tags:
     - postgresql


### PR DESCRIPTION
this fixes `Failed to import the required Python library (psycopg2)` for python3