### PR TITLE
Updates the Default Value for opensrp_configure_mysql

### DIFF
--- a/roles/opensrp/defaults/main.yml
+++ b/roles/opensrp/defaults/main.yml
@@ -5,7 +5,7 @@ opensrp_resource_sub_dirs:
   - "qr-codes"
 opensrp_mysql_port: 3306
 opensrp_mysql_host: "localhost"
-opensrp_configure_mysql: true
+opensrp_configure_mysql: false
 opensrp_mysql_database: "opensrp"
 opensrp_motech_database: "motechquartz"
 opensrp_mysql_user: "opensrp"


### PR DESCRIPTION
Since most OpenSRP installations no-longer use MySQL, set the default value for
opensrp_configure_mysql.