### PR TITLE
add openmrs_mysql_root_user_accessible_remotely config

### DIFF
--- a/roles/openmrs/defaults/main.yml
+++ b/roles/openmrs/defaults/main.yml
@@ -166,4 +166,5 @@ openmrs_logstash_custom_inputs:
       - '  git_version => "{{ openmrs_version }}"'
       - '}'
 
+# For new deployments it should be set to false since mysql role will be responsible for admin tasks e.g. create databases and users
 openmrs_mysql_root_user_accessible_remotely: true

--- a/roles/openmrs/defaults/main.yml
+++ b/roles/openmrs/defaults/main.yml
@@ -165,3 +165,5 @@ openmrs_logstash_custom_inputs:
       - '  from_{{ openmrs_system_user }} => true'
       - '  git_version => "{{ openmrs_version }}"'
       - '}'
+
+openmrs_mysql_root_user_accessible_remotely: true

--- a/roles/openmrs/tasks/main.yml
+++ b/roles/openmrs/tasks/main.yml
@@ -16,6 +16,7 @@
     login_password: "{{ openmrs_mysql_root_password }}"
     name: "{{ openmrs_mysql_database }}"
     state: present
+  when: openmrs_mysql_root_user_accessible_remotely
 
 - name: Create the OpenMRS MySQL User
   mysql_user:
@@ -27,6 +28,7 @@
     host: "{{ openmrs_mysql_app_host }}"
     priv: "{{ openmrs_mysql_database }}.*:{{ openmrs_mysql_user_privilages }}"
     state: present
+  when: openmrs_mysql_root_user_accessible_remotely
 
 - name: ensure openmrs_system_user exists
   become: yes

--- a/sample-inventories/inventory-a/group_vars/openmrs-app-servers/vars.yml
+++ b/sample-inventories/inventory-a/group_vars/openmrs-app-servers/vars.yml
@@ -76,3 +76,4 @@ openmrs_auto_update_database: "true"
 openmrs_encryption_vector: "strongpassword"
 openmrs_encryption_key: "strongpassword"
 opensrp_install_swap: true
+openmrs_mysql_root_user_accessible_remotely: false


### PR DESCRIPTION
The config `openmrs_mysql_root_user_accessible_remotely` is true for backward compatibility but it should be false for new deployments.

- The config eliminates need for root user to be accessible remotely.