### PR TITLE
add quotes to password to fix issue with password with special chars

### DIFF
--- a/roles/mysql-backup/templates/mysqlbkup_install_location/mysqlbkup.cnf.j2
+++ b/roles/mysql-backup/templates/mysqlbkup_install_location/mysqlbkup.cnf.j2
@@ -1,12 +1,12 @@
 [mysql]
 host={{ mysql_host }}
 user={{ mysql_backup_user }}
-password={{ mysql_backup_password }}
+password="{{ mysql_backup_password }}"
 
 [mysqldump]
 host={{ mysql_host }}
 user={{ mysql_backup_user }}
-password={{ mysql_backup_password }}
+password="{{ mysql_backup_password }}"
 force
 opt
 routines


### PR DESCRIPTION
Fixes issue whereby mysql failed to authenticate when password had special characters.